### PR TITLE
Add codesections to reviewers & 2 labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template-fallback.md
+++ b/.github/ISSUE_TEMPLATE/issue-template-fallback.md
@@ -3,7 +3,7 @@ name: Report another problem
 about: Basic template for reporting problems (if no other label fits)
 title: ''
 labels: 'fallback'
-assignees: 'AlexDaniel'
+assignees: 'codesections'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/issue-template-meta.md
+++ b/.github/ISSUE_TEMPLATE/issue-template-meta.md
@@ -3,7 +3,7 @@ name: Report a meta problem
 about: Changes to the problem-solving repo and this document
 title: ''
 labels: 'meta'
-assignees: 'AlexDaniel'
+assignees: 'codesections'
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ to be added as a responsible dev.
 
 * `meta` – changes to the `problem-solving` repo and this document
   * [@AlexDaniel](https://github.com/AlexDaniel)
+  * [@codesections](https://github.com/codesections)
 * `language` – changes to the [Raku language](https://github.com/perl6/roast/)
   * –
 * `rakudo` – big changes to [Rakudo](https://github.com/rakudo/rakudo/)
@@ -153,12 +154,14 @@ to be added as a responsible dev.
   * [@maettu](https://github.com/maettu)
 * `fallback` – if no other label fits
   * [@AlexDaniel](https://github.com/AlexDaniel)
+  * [@codesections](https://github.com/codesections)
 
 ## Reviewers
 
 File a `meta` issue if you want to be added to this list.
 
 * [@AlexDaniel](https://github.com/AlexDaniel)
+* [@codesections](https://github.com/codesections)
 * [@FCO](https://github.com/FCO)
 * [@JJ](https://github.com/JJ)
 * [@lizmat](https://github.com/lizmat/)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ File a `meta` issue if you want to create a new label or if you want
 to be added as a responsible dev.
 
 * `meta` – changes to the `problem-solving` repo and this document
-  * [@AlexDaniel](https://github.com/AlexDaniel)
   * [@codesections](https://github.com/codesections)
 * `language` – changes to the [Raku language](https://github.com/perl6/roast/)
   * –
@@ -153,14 +152,12 @@ to be added as a responsible dev.
   * [@rba](https://github.com/rba)
   * [@maettu](https://github.com/maettu)
 * `fallback` – if no other label fits
-  * [@AlexDaniel](https://github.com/AlexDaniel)
   * [@codesections](https://github.com/codesections)
 
 ## Reviewers
 
 File a `meta` issue if you want to be added to this list.
 
-* [@AlexDaniel](https://github.com/AlexDaniel)
 * [@codesections](https://github.com/codesections)
 * [@FCO](https://github.com/FCO)
 * [@JJ](https://github.com/JJ)


### PR DESCRIPTION
In this PR, I've added myself to the list of reviewers (in alphabetical order), and have also added myself as a "responsible dev" for the «meta» and «fallback» labels.